### PR TITLE
Allows keylime agent to be run as non-root (in this case, as "tss")

### DIFF
--- a/control
+++ b/control
@@ -9,7 +9,8 @@ Build-Depends:
   python3-simplejson,
   python3-zmq,
   python3-tornado,
-  python3-distutils
+  python3-distutils,
+  python3-gnupg
 Homepage: https://github.com/keylime/keylime.git
 
 Package: python3-keylime
@@ -22,7 +23,8 @@ Depends:
   python3-tornado,
   python3-distutils,
   python3-m2crypto,
-  python3-cryptography
+  python3-cryptography,
+  python3-gnupg
 Description: Open source TPM software for Bootstrapping and Maintaining Trust
   Keylime is a TPM based highly scalable remote boot attestation
   and runtime integrity measurement solution.

--- a/keylime_agent.service
+++ b/keylime_agent.service
@@ -4,6 +4,8 @@ StartLimitInterval=10s
 StartLimitBurst=5
 
 [Service]
+User=keylime
+Group=tss
 Environment=TPM2TOOLS_TCTI=device:/dev/tpmrm0
 ExecStart=/usr/bin/keylime_agent
 TimeoutSec=60s

--- a/postinst
+++ b/postinst
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    configure)
+        # creating tss group if he isn't already there
+        if ! getent group tss >/dev/null; then
+            addgroup --system tss
+        fi
+
+        # creating keylime user if he isn't already there
+        if ! getent passwd keylime >/dev/null; then
+            adduser --system --ingroup tss --shell /bin/false \
+                    --home /var/lib/keylime --no-create-home \
+                    --gecos "Keylime remote attestation" \
+                    keylime
+        fi
+
+        # Create keylime operational directory
+	if [ ! -d /var/lib/keylime ]; then mkdir -p /var/lib/keylime/secure
+	fi
+        
+	# Only root can mount tmpfs with `-o` 
+        if ! grep -qs '/var/lib/keylime/secure ' /proc/mounts ; then mount -t tmpfs -o size=1m,mode=0700 tmpfs /var/lib/keylime/secure
+	fi
+
+        # Setting owner
+        if [ -d /var/lib/keylime ] && getent passwd keylime >/dev/null; then
+            chown -R keylime:tss /var/lib/keylime
+        fi
+
+	# The "keylime" user belongs to tss, and we need to give access to /sys/kernel/security/<x>
+        chown -R tss:tss /sys/kernel/security/tpm0
+        chown -R tss:tss /sys/kernel/security/ima
+
+#        # ask udev to check for new udev rules (and fix device permissions)
+#        if udevadm --version > /dev/null; then
+#            udevadm control --reload-rules ||:
+#            udevadm trigger --sysname-match="tpm[0-9]*" ||:
+#            udevadm trigger --action=add --subsystem-match=tpm ||:
+#            udevadm trigger --action=add --subsystem-match=tpmrm ||:
+#        fi
+    ;;
+
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac


### PR DESCRIPTION
Signed-off-by: Marcio Silva <marcios@us.ibm.com>